### PR TITLE
Ignore README.rdoc in the install rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ desc "install the dot files into user's home directory"
 task :install do
   replace_all = false
   Dir['*'].each do |file|
-    next if %w[Rakefile README LICENSE id_dsa.pub].include? file
+    next if %w[Rakefile README.rdoc LICENSE id_dsa.pub].include? file
     
     if File.exist?(File.join(ENV['HOME'], ".#{file}"))
       if replace_all


### PR DESCRIPTION
I was testing out your dotfiles and noticed that your 
readme was actually getting copied to the user's home 
directory.
