### PR TITLE
Remove duplicated "set noesckeys" in vimrc

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -166,9 +166,6 @@ set tags=./tags;
 " Use Silver Searcher instead of grep
 set grepprg=ag
 
-" Get rid of the delay when hitting esc!
-set noesckeys
-
 " Make the omnicomplete text readable
 :highlight PmenuSel ctermfg=black
 


### PR DESCRIPTION
You have "set noesckeys" duplicated on line 205.
