### PR TITLE
Add tip for remapping C-s

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -133,6 +133,8 @@ map <Leader>v :vnew <C-R>=escape(expand("%:p:h"), ' ') . '/'<CR>
 
 map <C-h> :nohl<cr>
 imap <C-l> :<Space>
+" Note that remapping C-s requires flow control to be disabled
+" (e.g. in .bashrc or .zshrc)
 map <C-s> <esc>:w<CR>
 imap <C-s> <esc>:w<CR>
 map <C-t> <esc>:tabnew<CR>


### PR DESCRIPTION
You mentioned your C-s mapping on the Ruby Rogues podcast and it sounded useful. I checked your `.vimrc` and added the mappings, but it didn't work, and I couldn't figure out why. I thought maybe iTerm was using that mapping for something else.

I later realised that it's because C-s is traditionally used for flow control, and your `.zshrc` has entries to disable that behaviour.

Since there's a lot of interest in your dotfiles, I thought it was worth adding a tip to avoid others running into the same problem.
