### PR TITLE
Fix git path in Vundle.vim install instructions

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -14,5 +14,5 @@ I'm also a pretty aggressive aliaser. You might find a few you like in bash/alia
 
   Vim plugins are managed through vundle. You'll need to install vundle to get them.
 
-  git clone https://github.com/gmarik/vundle.git ~/.vim/bundle/vundle
+  git clone https://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim
   Run :BundleInstall in vim.


### PR DESCRIPTION
Vundle has been moved to gmarik/Vundle.vim. Fixed the installation instructions in the README.
