### PR TITLE
Auto-escape spaces in file names

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -106,7 +106,7 @@ map <Leader>h :CommandT<CR>
 map <Leader>i mmgg=G`m<CR>
 map <Leader>j :CommandT app/assets/javascripts<cr>client/
 map <Leader>l oconsole.log 'debugging'<esc>:w<cr>
-map <Leader>m :Rmodel 
+map <Leader>m :Rmodel
 map <Leader>nn :sp ~/Dropbox/notes/programming_notes.txt<cr>
 map <Leader>o :w<cr>:call RunCurrentLineInTest()<CR>
 map <Leader>p :set paste<CR>o<esc>"*]p:set nopaste<cr>
@@ -118,23 +118,23 @@ map <Leader>rs :vsp <C-r>#<cr><C-w>w
 map <Leader>rt q:?!ruby<cr><cr>
 map <Leader>rw :%s/\s\+$//<cr>:w<cr>
 map <Leader>sc :sp db/schema.rb<cr>
-map <Leader>sg :sp<cr>:grep 
+map <Leader>sg :sp<cr>:grep
 map <Leader>sj :call OpenJasmineSpecInBrowser()<cr>
-map <Leader>sm :RSmodel 
+map <Leader>sm :RSmodel
 map <Leader>sp yss<p>
 map <Leader>sn :e ~/.vim/snippets/ruby.snippets<CR>
 map <Leader>so :so %<cr>
 map <Leader>sq j<c-v>}klllcs<esc>:wq<cr>
 map <Leader>ss ds)i <esc>:w<cr>
 map <Leader>st :!ruby -Itest % -n "//"<left><left>
-map <Leader>su :RSunittest 
-map <Leader>sv :RSview 
+map <Leader>su :RSunittest
+map <Leader>sv :RSview
 map <Leader>t :w<cr>:call RunCurrentTest()<CR>
 map <Leader>y :!rspec --drb %<cr>
 map <Leader>u :Runittest<cr>
 map <Leader>vc :RVcontroller<cr>
 map <Leader>vf :RVfunctional<cr>
-map <Leader>vg :vsp<cr>:grep 
+map <Leader>vg :vsp<cr>:grep
 map <Leader>vi :tabe ~/.vimrc<CR>
 map <Leader>vu :RVunittest<CR>
 map <Leader>vm :RVmodel<cr>
@@ -209,14 +209,14 @@ let g:fuzzy_ignore = "*.png;*.PNG;*.JPG;*.jpg;*.GIF;*.gif;vendor/**;coverage/**;
 highlight StatusLine ctermfg=blue ctermbg=yellow
 
 " Format xml files
-au FileType xml exe ":silent 1,$!xmllint --format --recover - 2>/dev/null" 
+au FileType xml exe ":silent 1,$!xmllint --format --recover - 2>/dev/null"
 
 set shiftround " When at 3 spaces and I hit >>, go to 4, not 5.
 
 set nofoldenable " Say no to code folding...
 
 command! Q q " Bind :Q to :q
-command! Qall qall 
+command! Qall qall
 
 
 " Disable Ex mode
@@ -381,11 +381,11 @@ highlight SignColumn ctermbg=black
 " RENAME CURRENT FILE (thanks Gary Bernhardt)
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 function! RenameFile()
-    let old_name = expand('%')
-    let new_name = input('New file name: ', expand('%'), 'file')
+    let old_name = escape(expand('%'), ' ')
+    let new_name = escape(input('New file name: ', '', 'file'), ' ')
     if new_name != '' && new_name != old_name
         exec ':saveas ' . new_name
-        exec ':silent !rm ' . old_name
+        exec ':silent !rm -rf ' . old_name
         redraw!
     endif
 endfunction


### PR DESCRIPTION
I love your RenameFile() function. However there are two problems.
The first one is that some files have spaces in their names. The
solution is to use escape() function to escape those spaces.
The second one is that I created an alias for my rm command. I am using
“rm -i” for rm, so I can not delete the origin file when I am using
MacVim (I don’t know why it doesn’t prompt me to enter “y”). The
solution is to add “-rf”.
